### PR TITLE
Updated-speaking

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3)
+    activesupport (7.1.3.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -25,8 +25,7 @@ GEM
     connection_pool (2.4.1)
     dnsruby (1.70.0)
       simpleidn (~> 0.2.1)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -96,8 +95,9 @@ GEM
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.0)
-    i18n (1.14.1)
+    i18n (1.14.3)
       concurrent-ruby (~> 1.0)
+      racc (~> 1.7)
     jekyll (3.9.5)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -214,7 +214,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.8.0)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
@@ -242,7 +242,6 @@ GEM
       ffi (~> 1.0)
     rexml (3.2.6)
     rouge (3.30.0)
-    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sass (3.7.4)

--- a/_pages/speaking.md
+++ b/_pages/speaking.md
@@ -20,14 +20,19 @@ You can find some of my previous talks and online engagements on YouTube at the 
 | Event | Date | Talks |
 | --- | --- | --- |
 | 90 Days of DevOps | Dec, 2023 | Working with DevContainers |
-| NDC Sydney 2024 | Feb 12-16, 2024 | NET in a Box: Containerizing .NET Applications |
-| Orlando Code Camp 2024 | Feb 24, 2024 | NET in a Box: Containerizing .NET Applications |
 | PowerShell + DevOps Summit 2024 | Apr 8-11, 2024 | CI/CD With GitHub Actions<br/>SRE, DevOps, and Platform Engineering: Unraveling the Differences |
+| Techorama Belgium 2024 | May 6-8, 2024 | .NET in a Box: Containerizing .NET Applications<br />.NET Configuration In Depth |
+| SDD 2024 | May 13-17, 2024 | .NET Configuration In Depth<br />Building in the Cloud with Bicep<br />Kubernetes resiliency |
+| DevSum 2024 | May 16-17, 2024 | .NET in a Box: Containerizing .NET Applications |
+| Developer Week 2024 | July 1-5, 2024 | The Power of Dev Containers and GitHub Codespaces |
+| KCDC 2024 | June 26-28, 2024 | .NET Configuration In Depth<br />CI/CD with Github Actions |
 
 ## Past Events
 
 | Event | Date | Talks |
 | --- | --- | --- |
+| Orlando Code Camp 2024 | Feb 24, 2024 | NET in a Box: Containerizing .NET Applications |
+| NDC Sydney 2024 | Feb 12-16, 2024 | NET in a Box: Containerizing .NET Applications |
 | Festive Tech Calendar | Dec 27, 2023 | Dev Containers in VS Code |
 | Granite State Code Camp 2023 | Dec 2, 2023 | CI/CD with GitHub Actions |
 | Live360! Orlando | Nov 13-17, 2023 | Achieving SRE (Site Resiliency Engineering) with Azure<br>Master Azure Resources Like Marvel's Lord Chaos<br>Cloud & Containers Live! Panel Discussion: Past the Hype: Cloud in the Mainstream |


### PR DESCRIPTION
This pull request includes changes to the `_pages/speaking.md` file. The changes involve updating the list of future and past speaking engagements. 

The most significant changes include:

* `You can find some of my previous talks and online engagements on YouTube at the` in `_pages/speaking.md`: The future events "NDC Sydney 2024" and "Orlando Code Camp 2024" have been removed and added to the past events section. New future events have been added, including "Techorama Belgium 2024", "SDD 2024", "DevSum 2024", "Developer Week 2024", and "KCDC 2024".