### PR TITLE
Fix: Downgrade Hugo to 0.135.0 for Blowfish compatibility

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.140.2
+      HUGO_VERSION: 0.135.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the warning: 'Module blowfish is not compatible with this Hugo version: 0.87.0/0.135.0'

This PR downgrades Hugo from 0.140.2 to 0.135.0 to ensure compatibility with the Blowfish theme, which currently supports Hugo versions between 0.87.0 and 0.135.0.

Related to the Blowfish theme compatibility issue mentioned in https://github.com/nunocoracao/blowfish/issues/1658