### PR TITLE
Add blog post: Promoted to Principal Software Engineer

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -63,6 +63,7 @@ jobs:
           hugo \
             --gc \
             --minify \
+            --buildFuture \
             --baseURL "${BASE_URL}/"
 
       - name: Upload artifact

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -3,6 +3,8 @@ name: Deploy Hugo site to Pages
 on:
   push:
     branches: [main]
+  schedule:
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 permissions:
@@ -63,7 +65,6 @@ jobs:
           hugo \
             --gc \
             --minify \
-            --buildFuture \
             --baseURL "${BASE_URL}/"
 
       - name: Upload artifact

--- a/content/posts/2026-02-23-promoted-to-principal-swe.md
+++ b/content/posts/2026-02-23-promoted-to-principal-swe.md
@@ -1,6 +1,6 @@
 ---
 title: Promoted to Principal Software Engineer at Microsoft
-date: '2026-02-24'
+date: '2026-02-23'
 categories:
 - Blog
 tags:
@@ -9,7 +9,7 @@ tags:
 image: images/mslogo.png
 featureImage: images/mslogo.png
 aliases:
-- /2026/02/24/promoted-to-principal-swe/
+- /2026/02/23/promoted-to-principal-swe/
 slug: promoted-to-principal-swe
 ---
 

--- a/content/posts/2026-02-24-promoted-to-principal-swe.md
+++ b/content/posts/2026-02-24-promoted-to-principal-swe.md
@@ -34,6 +34,26 @@ As a Principal Software Engineer, I'm continuing to focus on Azure reliability -
 - **Community** - organizing DevOps Days Tampa Bay, mentoring, and contributing to open source
 - **Writing** - more blog posts, more samples, more sharing
 
+## What Does Principal Mean at Microsoft
+
+For those curious about what this level means at Microsoft, I wanted to share some context. At Microsoft, engineering levels form a career ladder, and the jump from Senior to Principal represents a meaningful shift in scope, impact, and expectations.
+
+A **Senior Software Engineer** (levels 63-64) typically executes complex features, leads projects within a single team, designs components, reviews code, and mentors team members. The focus is largely on the *how* - delivering high-quality work within established frameworks.
+
+A **Principal Software Engineer** (levels 65-67) operates differently. The role shifts toward strategic technical leadership - defining architecture across multiple teams, solving organization-wide problems, and aligning technology decisions with business goals. The focus moves to the *why* - long-term strategy, navigating high ambiguity, and innovating beyond existing solutions.
+
+Some of the key differences:
+
+- **Scope of Impact** - Senior engineers own projects within a team. Principals influence entire organizations, divisions, or large-scale technical strategies
+- **Technical Focus** - Principals handle high ambiguity and innovate beyond existing solutions. Seniors work within established frameworks to deliver features
+- **Leadership** - Principals guide technical direction, manage stakeholders, and mentor other senior engineers. Seniors focus more on day-to-day implementation and mentoring junior staff
+
+For more perspective on the Principal role at Microsoft, these discussions are worth reading:
+
+- [What is a Principal Engineer at Microsoft](https://newsletter.techworld-with-milan.com/p/what-is-a-principal-engineer-at-microsoft) - Tech World with Milan
+- [Difference between Senior vs Principal SWE](https://www.reddit.com/r/ExperiencedDevs/comments/s7uiba/difference_between_senior_vs_principal_swe/) - r/ExperiencedDevs
+- [Discussion on Principal Engineer expectations](https://news.ycombinator.com/item?id=29551528) - Hacker News
+
 ## Gratitude
 
 None of this happens alone. I'm grateful for the incredible teammates and mentors I've had on both teams, the managers who championed my growth, and the community that keeps pushing me to learn and share. And of course, my family - who support all the late nights, conference travel, and the constant tinkering.

--- a/content/posts/2026-02-24-promoted-to-principal-swe.md
+++ b/content/posts/2026-02-24-promoted-to-principal-swe.md
@@ -1,0 +1,43 @@
+---
+title: Promoted to Principal Software Engineer at Microsoft
+date: '2026-02-24'
+categories:
+- Blog
+tags:
+- Microsoft
+- Career
+image: images/mslogo.png
+featureImage: images/mslogo.png
+aliases:
+- /2026/02/24/promoted-to-principal-swe/
+slug: promoted-to-principal-swe
+---
+
+I'm thrilled to share that I've been promoted to **Principal Software Engineer** at Microsoft!
+
+<!--more-->
+
+## The Journey
+
+It's been an incredible four and a half years at Microsoft, and this milestone still feels a bit surreal. When I [joined Microsoft in October 2021](/posts/time-to-follow-my-dream-im-joining-microsoft/) as a Senior Customer Engineer on the Fast Track for Azure (FTA) team, I was living a dream I'd had since childhood. I never imagined the journey would bring me here.
+
+During my time on the FTA team, I worked directly with customers adopting Azure, helping them architect and build cloud-native solutions. It was an amazing experience - every engagement brought new challenges, new architectures, and new opportunities to learn and teach.
+
+In late 2024, I [moved to the Azure Reliability (AzRel) Risk SRE team](/posts/new-team-new-focus/), a shift that pushed me into entirely new territory. As the lead for the Platform Reliability Pillar, I dove into outage analysis, building AI-driven tooling with OpenAI and Semantic Kernel to help engineers understand failures and strengthen Azure's reliability at scale. It was a big change, but it reinforced something I've always believed - growth comes from stepping into the unfamiliar.
+
+## Looking Forward
+
+As a Principal Software Engineer, I'm continuing to focus on Azure reliability - building tools and systems that help keep the platform running smoothly for millions of users worldwide. I'm also doubling down on the things I'm passionate about:
+
+- **Building** - AI-powered tooling for reliability engineering, distributed systems, and cloud-native applications
+- **Speaking** - sharing what I've learned at conferences around the world, from NDC and Techorama to DevSum and Aspire Conf
+- **Community** - organizing DevOps Days Tampa Bay, mentoring, and contributing to open source
+- **Writing** - more blog posts, more samples, more sharing
+
+## Gratitude
+
+None of this happens alone. I'm grateful for the incredible teammates and mentors I've had on both teams, the managers who championed my growth, and the community that keeps pushing me to learn and share. And of course, my family - who support all the late nights, conference travel, and the constant tinkering.
+
+If you're on your own career journey, here's what I'd say: don't be afraid to take the leap into unfamiliar territory. The skills you've built are more transferable than you think, and the best growth happens outside your comfort zone. I gave a [whole talk about this](/speaking/) - *Refactoring Your Technical Identity* - and I truly believe it.
+
+Here's to the next chapter. Let's build something great.

--- a/content/posts/2026-02-24-promoted-to-principal-swe.md
+++ b/content/posts/2026-02-24-promoted-to-principal-swe.md
@@ -48,11 +48,9 @@ Some of the key differences:
 - **Technical Focus** - Principals handle high ambiguity and innovate beyond existing solutions. Seniors work within established frameworks to deliver features
 - **Leadership** - Principals guide technical direction, manage stakeholders, and mentor other senior engineers. Seniors focus more on day-to-day implementation and mentoring junior staff
 
-For more perspective on the Principal role at Microsoft, these discussions are worth reading:
+For me, this promotion reflects the way I've been working - constantly sharing knowledge, educating the team, and helping set technical direction. Whether it's building alignment across orgs and teams, driving architecture decisions, or connecting people and ideas across organizational boundaries, the Principal role formalizes what I believe great engineering looks like at scale.
 
-- [What is a Principal Engineer at Microsoft](https://newsletter.techworld-with-milan.com/p/what-is-a-principal-engineer-at-microsoft) - Tech World with Milan
-- [Difference between Senior vs Principal SWE](https://www.reddit.com/r/ExperiencedDevs/comments/s7uiba/difference_between_senior_vs_principal_swe/) - r/ExperiencedDevs
-- [Discussion on Principal Engineer expectations](https://news.ycombinator.com/item?id=29551528) - Hacker News
+At its core, it comes down to a **growth mindset**. The willingness to step into ambiguity, learn continuously, and lift others up along the way. That's what got me here, and it's what I'll keep doing.
 
 ## Gratitude
 

--- a/content/posts/2026-02-24-promoted-to-principal-swe.md
+++ b/content/posts/2026-02-24-promoted-to-principal-swe.md
@@ -56,6 +56,6 @@ At its core, it comes down to a **growth mindset**. The willingness to step into
 
 None of this happens alone. I'm grateful for the incredible teammates and mentors I've had on both teams, the managers who championed my growth, and the community that keeps pushing me to learn and share. And of course, my family - who support all the late nights, conference travel, and the constant tinkering.
 
-If you're on your own career journey, here's what I'd say: don't be afraid to take the leap into unfamiliar territory. The skills you've built are more transferable than you think, and the best growth happens outside your comfort zone. I gave a [whole talk about this](/speaking/) - *Refactoring Your Technical Identity* - and I truly believe it.
+If you're on your own career journey, here's what I'd say: don't be afraid to take the leap into unfamiliar territory. The skills you've built are more transferable than you think, and the best growth happens outside your comfort zone.
 
 Here's to the next chapter. Let's build something great.

--- a/content/posts/2026-02-24-promoted-to-principal-swe.md
+++ b/content/posts/2026-02-24-promoted-to-principal-swe.md
@@ -31,7 +31,7 @@ As a Principal Software Engineer, I'm continuing to focus on Azure reliability -
 
 - **Building** - AI-powered tooling for reliability engineering, distributed systems, and cloud-native applications
 - **Speaking** - sharing what I've learned at conferences around the world, from NDC and Techorama to DevSum and Aspire Conf
-- **Community** - organizing DevOps Days Tampa Bay, mentoring, and contributing to open source
+- **Community** - organizing DevOps Days Tampa Bay, active with Tampa Devs and multiple local meetups, mentoring, and contributing to open source
 - **Writing** - more blog posts, more samples, more sharing
 
 ## What Does Principal Mean at Microsoft


### PR DESCRIPTION
New post dated Feb 23 celebrating promotion to Principal SWE at Microsoft. Covers the 4.5-year journey from FTA to AzRel Risk SRE, looking forward, and career advice.