### PR TITLE
chore: update blowfish submodule to v2.98.0

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -26,7 +26,7 @@ jobs:
       pages: write
       id-token: write
     env:
-      HUGO_VERSION: 0.154.5
+      HUGO_VERSION: 0.155.3
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Updates the Blowfish theme submodule to v2.98.0.