### PR TITLE
fix: remove duplicate RSS output to prevent double posts on dev.to

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -45,7 +45,7 @@ googleAnalytics = "" # Add your GA4 measurement ID
   priority = 0.5
 
 [outputs]
-  home = ["HTML", "RSS", "FEED", "JSON"]
+  home = ["HTML", "FEED", "JSON"]
 
 # Legacy feed.xml for backward compatibility with Jekyll
 [outputFormats.FEED]

--- a/content/posts/2026-01-18-migrating-from-jekyll-to-hugo-part2.md
+++ b/content/posts/2026-01-18-migrating-from-jekyll-to-hugo-part2.md
@@ -190,7 +190,7 @@ Get-ChildItem "content/posts/*.md" | ForEach-Object {
 ```
 
 {{< alert "circle-info" >}}
-**Note:** The PowerShell script above covers the basics, but you may need additional passes for things like Liquid `{% raw %}` blocks or custom Jekyll includes. Test thoroughly!
+**Note:** The PowerShell script above covers the basics, but you may need additional passes for things like Liquid `raw`/`endraw` blocks or custom Jekyll includes. Test thoroughly!
 {{< /alert >}}
 
 ## What's Next

--- a/layouts/_default/feed.xml
+++ b/layouts/_default/feed.xml
@@ -24,7 +24,7 @@
     <copyright>{{ with replace .Site.Params.copyright "{ year }" now.Year }}{{.}}{{ else }}© {{ now.Format "2006" }} {{ .Site.Params.Author.name }}{{- end }}</copyright>
     {{- end }}
     {{ if not .Date.IsZero }}<lastBuildDate>{{ (index $pages.ByLastmod.Reverse 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
-    {{- with .OutputFormats.Get "RSS" -}}
+    {{- with .OutputFormats.Get "FEED" -}}
     {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{- end -}}
     {{ if and (.Site.Params.rssnext.feedId) (.Site.Params.rssnext.userId) }}


### PR DESCRIPTION
## Problem
The site generates two RSS feeds with identical content:
- index.xml (from the RSS output format)
- feed.xml (from the FEED output format)

Both feeds are advertised in the HTML head via link alternate tags, so feed importers like dev.to discover and import from both, causing every post to appear twice.

## Fix
- Remove RSS from the home output formats, keeping only FEED (feed.xml) for backward compatibility with the original Jekyll site
- Fix the atom:link self-reference in feed.xml to correctly point to the FEED output format instead of the now-removed RSS format
