### PR TITLE
fix: resolve broken images on books and about pages

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -5,11 +5,11 @@ aliases:
   - /about/
 ---
 
-<div style="display: flex; flex-wrap: wrap; justify-content: center; gap: 24px; margin-bottom: 1.5rem;">
-  <a href="/images/bio-photo.jpg" target="_blank"><img src="/images/bio-photo.jpg" alt="Chris Ayers" style="width: 240px; height: 240px; border-radius: 50%; object-fit: cover; border: 3px solid var(--color-primary-500);" /></a>
-  <a href="/images/head-shoulders.png" target="_blank"><img src="/images/head-shoulders.png" alt="Chris Ayers headshot" style="width: 240px; height: 240px; border-radius: 50%; object-fit: cover; border: 3px solid var(--color-primary-500);" /></a>
-  <a href="/images/kcdc-2025-1.jpg" target="_blank"><img src="/images/kcdc-2025-1.jpg" alt="Chris Ayers speaking at KCDC 2025" style="width: 240px; height: 240px; border-radius: 50%; object-fit: cover; border: 3px solid var(--color-primary-500);" /></a>
-</div>
+{{< gallery >}}
+  <img src="/images/bio-photo.jpg" alt="Chris Ayers" class="grid-w33" style="border-radius: 50%; object-fit: cover; border: 3px solid var(--color-primary-500);" />
+  <img src="/images/head-shoulders.png" alt="Chris Ayers headshot" class="grid-w33" style="border-radius: 50%; object-fit: cover; border: 3px solid var(--color-primary-500);" />
+  <img src="/images/kcdc-2025-1.jpg" alt="Chris Ayers speaking at KCDC 2025" class="grid-w33" style="border-radius: 50%; object-fit: cover; border: 3px solid var(--color-primary-500);" />
+{{< /gallery >}}
 
 {{< lead >}}
 **Principal Software Engineer at Microsoft** | Azure Reliability | International Speaker

--- a/content/books.md
+++ b/content/books.md
@@ -9,6 +9,7 @@ I read a lot of books, you can see some of them on [goodreads](https://www.goodr
 
 ## DevOps and Engineering
 
+{{< gallery >}}
 <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 not-prose">
   <a href="https://itrevolution.com/accelerate-book/" class="group block rounded-lg border border-neutral-200 dark:border-neutral-700 p-4 hover:border-primary-500 dark:hover:border-primary-400 transition-all hover:shadow-lg">
     <img src="/images/books/accelerate.jpg" alt="Accelerate" class="w-full h-48 object-contain mb-3 rounded">
@@ -41,9 +42,11 @@ I read a lot of books, you can see some of them on [goodreads](https://www.goodr
     <p class="text-xs text-neutral-500 dark:text-neutral-400">An Engineers Field Guide to Technical Writing</p>
   </a>
 </div>
+{{< /gallery >}}
 
 ## Presentations and Productivity
 
+{{< gallery >}}
 <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 not-prose">
   <a href="https://www.duarte.com/books/slideology/" class="group block rounded-lg border border-neutral-200 dark:border-neutral-700 p-4 hover:border-primary-500 dark:hover:border-primary-400 transition-all hover:shadow-lg">
     <img src="/images/books/slide-ology.jpg" alt="slide:ology" class="w-full h-48 object-contain mb-3 rounded">
@@ -61,9 +64,11 @@ I read a lot of books, you can see some of them on [goodreads](https://www.goodr
     <p class="text-xs text-neutral-500 dark:text-neutral-400">A Proven Method to Organize Your Digital Life</p>
   </a>
 </div>
+{{< /gallery >}}
 
 ## Leadership and Management
 
+{{< gallery >}}
 <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 not-prose">
   <a href="https://www.radicalcandor.com/the-book/" class="group block rounded-lg border border-neutral-200 dark:border-neutral-700 p-4 hover:border-primary-500 dark:hover:border-primary-400 transition-all hover:shadow-lg">
     <img src="/images/books/radical-candor.png" alt="Radical Candor" class="w-full h-48 object-contain mb-3 rounded">
@@ -76,3 +81,4 @@ I read a lot of books, you can see some of them on [goodreads](https://www.goodr
     <p class="text-xs text-neutral-500 dark:text-neutral-400">Being a Great Manager Is Simpler Than You Think</p>
   </a>
 </div>
+{{< /gallery >}}


### PR DESCRIPTION
## Problem
Images on the Books and About Me pages were returning 404 errors. The images live in assets/images/ but were referenced via raw HTML img tags, which require files in static/images/ for direct URL serving.

## Fix
Wrapped the image sections in Blowfish gallery shortcode, which uses Hugo resources.GetMatch to resolve image paths from the assets/ directory. This is the same pattern already used successfully for the certification badge images on the About page.

### Changes
- books.md: Wrapped all three book grid sections in gallery shortcodes
- about.md: Replaced raw HTML headshot div with gallery shortcode

### Images fixed
- 11 book cover images on /books/
- 2 headshot images on /about/ (head-shoulders.png, kcdc-2025-1.jpg)