### PR TITLE
Add Capital Area .NET meetup to speaking page

### DIFF
--- a/content/speaking.md
+++ b/content/speaking.md
@@ -78,6 +78,7 @@ I regularly speak at conferences and meetups around the world. If you're interes
 
 | Event | Date | Talks |
 | --- | --- | --- |
+| [Capital Area .NET User Group](https://www.meetup.com/caparea-net/) | Jul 7 | Aspire 13: One AppHost, Many Languages |
 | [DevSum 2026](https://www.devsum.se) | Jun 2-3 | Refactoring Your Technical Identity |
 | | | Guardians of the Containers |
 | [Techorama Belgium 2026](https://techorama.be/) | May 11-13 | MITRE ATT&CK for Developers |


### PR DESCRIPTION
Adds a recent speaking engagement to the 2026 Past Events list on the speaking page.

## Change
- **Capital Area .NET User Group** — Jul 7, 2026 — "Aspire 13: One AppHost, Many Languages" (joined virtually; hybrid event)

Placed at the top of the 2026 Past Events table since Jul 7 is the most recent 2026 date.

## Notes
- Verified all conferences from `update/speaking-page-april-2026` are already present on `main` (that branch is an older subset — nothing missing).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>